### PR TITLE
Add `JakeBecker.elixir-ls` to recommended VSCode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "jakebecker.elixir-ls"
+    ]
+}


### PR DESCRIPTION
I haven't worked much with Elixir, so when I went to open `.exs` files in VSCode, I didn't have syntax highlighting or anything like that.

It looks like [this extension](https://marketplace.visualstudio.com/items?itemName=JakeBecker.elixir-ls) is the most popular, so I added it as a suggested extension for the project. After merging this PR, users who open the project in VSCode will be prompted to install this recommended extension, which should help onboarding.