### PR TITLE
Add `urls` property to `Prediction`

### DIFF
--- a/lib/mock_client.ex
+++ b/lib/mock_client.ex
@@ -11,7 +11,11 @@ defmodule Replicate.MockClient do
     version: "27b93a2413e7f36cd83da926f3656280b2931564ff050bf9575f1fdf9bcd7478",
     output: [
       "https://replicate.com/api/models/stability-ai/stable-diffusion/files/50fcac81-865d-499e-81ac-49de0cb79264/out-0.png"
-    ]
+    ],
+    urls: %{
+      "get" => "https://api.replicate.com/v1/predictions/1234",
+      "cancel" => "https://api.replicate.com/v1/predictions/1234/cancel",
+    }
   }
   @stub_prediction2 %{
     id: "1235",
@@ -20,7 +24,11 @@ defmodule Replicate.MockClient do
     version: "27b93a2413e7f36cd83da926f3656280b2931564ff050bf9575f1fdf9bcd7478",
     output: [
       "https://replicate.com/api/models/stability-ai/stable-diffusion/files/50fcac81-865d-499e-81ac-49de0cb79264/out-0.png"
-    ]
+    ],
+    urls: %{
+      "get" => "https://api.replicate.com/v1/predictions/1235",
+      "cancel" => "https://api.replicate.com/v1/predictions/1235/cancel",
+    }
   }
 
   @stub_version1 %{

--- a/lib/predictions.ex
+++ b/lib/predictions.ex
@@ -165,15 +165,23 @@ defmodule Replicate.Predictions do
     status: "starting",
     input: %{"prompt" => "a 19th century portrait of a wombat gentleman"},
     version: "27b93a2413e7f36cd83da926f3656280b2931564ff050bf9575f1fdf9bcd7478",
-    output: ["https://replicate.com/api/models/stability-ai/stable-diffusion/files/50fcac81-865d-499e-81ac-49de0cb79264/out-0.png"]
-    },
+    output: ["https://replicate.com/api/models/stability-ai/stable-diffusion/files/50fcac81-865d-499e-81ac-49de0cb79264/out-0.png"],
+    urls: %{
+      "get" => "https://api.replicate.com/v1/predictions/1234",
+      "cancel" => "https://api.replicate.com/v1/predictions/1234/cancel",
+    }
+   },
    %Prediction{
     id: "1235",
     status: "starting",
     input: %{"prompt" => "a 19th century portrait of a wombat gentleman"},
     version: "27b93a2413e7f36cd83da926f3656280b2931564ff050bf9575f1fdf9bcd7478",
-    output: ["https://replicate.com/api/models/stability-ai/stable-diffusion/files/50fcac81-865d-499e-81ac-49de0cb79264/out-0.png"]}
-  ]
+    output: ["https://replicate.com/api/models/stability-ai/stable-diffusion/files/50fcac81-865d-499e-81ac-49de0cb79264/out-0.png"],
+    urls: %{
+      "get" => "https://api.replicate.com/v1/predictions/1235",
+      "cancel" => "https://api.replicate.com/v1/predictions/1235/cancel"
+    }
+  }]
   ```
   """
   def list() do

--- a/lib/predictions/prediction.ex
+++ b/lib/predictions/prediction.ex
@@ -10,8 +10,8 @@ defmodule Replicate.Predictions.Prediction do
     :output,
     :status,
     :version,
-    :started_at,
     :created_at,
+    :started_at,
     :completed_at
   ]
 end

--- a/lib/predictions/prediction.ex
+++ b/lib/predictions/prediction.ex
@@ -10,6 +10,7 @@ defmodule Replicate.Predictions.Prediction do
     :output,
     :status,
     :version,
+    :urls,
     :created_at,
     :started_at,
     :completed_at

--- a/test/replicate_test.exs
+++ b/test/replicate_test.exs
@@ -24,11 +24,13 @@ defmodule ReplicateTest do
         prompt: "a 19th century portrait of a wombat gentleman"
       })
 
-    assert prediction.status == "starting"
-    assert prediction.input == %{"prompt" => "a 19th century portrait of a wombat gentleman"}
-
     assert prediction.version ==
              "27b93a2413e7f36cd83da926f3656280b2931564ff050bf9575f1fdf9bcd7478"
+
+    assert prediction.status == "starting"
+    assert prediction.input == %{"prompt" => "a 19th century portrait of a wombat gentleman"}
+    assert prediction.urls["get"] == "https://api.replicate.com/v1/predictions/1234"
+    assert prediction.urls["cancel"] == "https://api.replicate.com/v1/predictions/1234/cancel"
   end
 
   test "create and wait prediction" do


### PR DESCRIPTION
Replicate's API provides a [`urls` field](https://replicate.com/docs/reference/http#predictions.get) in responses for predictions and trainings. This PR adds this property to the corresponding models.