### PR TITLE
Add deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install by adding `replicate` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:replicate, "~> 1.0.0"}
+    {:replicate, "~> 1.0.2"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install by adding `replicate` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:replicate, "~> 1.0.2"}
+    {:replicate, "~> 1.0.3"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -219,4 +219,15 @@ iex> {{_, 200, 'OK'}, _headers, body} = resp
 iex> File.write!("babadook_watercolor.jpg", body)
 ```
 
+## Create prediction from deployment
+
+Deployments allow you to control the configuration of a model with a private, fixed API endpoint. You can control the version of the model, the hardware it runs on, and how it scales.
+
+Once you create a deployment on Replicate, you can make predictions like this:
+
+```elixir
+iex> {:ok, deployment} = Replicate.Deployments.get("test/model")
+iex> {:ok, prediction} = Replicate.Deployments.create_prediction(deployment, %{prompt: "a 19th century portrait of a wombat gentleman"})
+```
+
 # replicate-elixir

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install by adding `replicate` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:replicate, "~> 1.1.0"}
+    {:replicate, "~> 1.1.1"}
   ]
 end
 ```

--- a/lib/client.ex
+++ b/lib/client.ex
@@ -5,6 +5,7 @@ defmodule Replicate.Client do
   @host Application.compile_env(:replicate, :replicate_base_url, "https://api.replicate.com")
   @behaviour Replicate.Client.Behaviour
   @poll_interval Application.compile_env(:replicate, :replicate_poll_interval, 500)
+  @timeout Application.compile_env(:replicate, :replicate_timeout, 60_000)
 
   alias Replicate.Predictions
   alias Replicate.Predictions.Prediction
@@ -21,7 +22,10 @@ defmodule Replicate.Client do
   def request(method, path), do: request(method, path, [])
 
   def request(method, path, body) do
-    case HTTPoison.request!(method, "#{@host}#{path}", body, header()) do
+    case HTTPoison.request!(method, "#{@host}#{path}", body, header(),
+           timeout: @timeout,
+           recv_timeout: @timeout
+         ) do
       %HTTPoison.Response{status_code: 200, body: body} ->
         {:ok, body}
 

--- a/lib/deployments.ex
+++ b/lib/deployments.ex
@@ -34,8 +34,6 @@ defmodule Replicate.Deployments do
 
   ```
   iex> {:ok, deployment} = Replicate.Deployments.get("test/model")
-  iex> model = Replicate.Models.get!("stability-ai/stable-diffusion")
-  iex> version = Replicate.Models.get_version!(model, "db21e45d3f7023abc2a46ee38a23973f6dce16bb082a930b0c49861f96d1e5bf")
   iex> {:ok, prediction} = Replicate.Deployments.create_prediction(deployment, version, %{prompt: "a 19th century portrait of a wombat gentleman"})
   iex> prediction.status
   "starting"
@@ -43,7 +41,6 @@ defmodule Replicate.Deployments do
   """
   def create_prediction(
         %Deployment{username: username, name: name},
-        %Version{id: version_id},
         input,
         webhook \\ nil,
         webhook_completed \\ nil,
@@ -62,7 +59,6 @@ defmodule Replicate.Deployments do
 
     body =
       %{
-        "version" => version_id,
         "input" => input |> Enum.into(%{})
       }
       |> Map.merge(webhook_parameters)

--- a/lib/deployments.ex
+++ b/lib/deployments.ex
@@ -1,0 +1,42 @@
+defmodule Replicate.Deployments do
+  @moduledoc """
+  Documentation for `Predictions`.
+  """
+  @behaviour Replicate.Deployments.Behaviour
+  alias Replicate.Deployments.Deployment
+  @replicate_client Application.compile_env(:replicate, :replicate_client, Replicate.Client)
+
+  @doc """
+  Gets a deployment by name, in the format `owner/model-name`.
+
+  ## Examples
+
+  ```
+  iex> {:ok, deployment} = Replicate.Deployments.get("test/model")
+  iex> deployment.username
+  "test"
+
+  iex> Replicate.Predictions.get("not_a_real_id")
+  {:error, "Not found"}
+  ```
+  """
+  def get(name) do
+    [owner, model_name] = String.split(name, "/")
+    {:ok, %Deployment{username: owner, name: model_name}}
+  end
+
+  defp parse_response({:ok, json_body}) do
+    body =
+      json_body
+      |> Jason.decode!()
+      |> string_to_atom()
+
+    {:ok, struct(Prediction, body)}
+  end
+
+  defp parse_response({:error, message}), do: {:error, message}
+
+  defp string_to_atom(body) do
+    for {k, v} <- body, into: %{}, do: {String.to_atom(k), v}
+  end
+end

--- a/lib/deployments.ex
+++ b/lib/deployments.ex
@@ -4,8 +4,8 @@ defmodule Replicate.Deployments do
   """
   @behaviour Replicate.Deployments.Behaviour
   @replicate_client Application.compile_env(:replicate, :replicate_client, Replicate.Client)
+
   alias Replicate.Deployments.Deployment
-  alias Replicate.Models.Version
   alias Replicate.Predictions.Prediction
 
   @doc """

--- a/lib/deployments.ex
+++ b/lib/deployments.ex
@@ -34,7 +34,7 @@ defmodule Replicate.Deployments do
 
   ```
   iex> {:ok, deployment} = Replicate.Deployments.get("test/model")
-  iex> {:ok, prediction} = Replicate.Deployments.create_prediction(deployment, version, %{prompt: "a 19th century portrait of a wombat gentleman"})
+  iex> {:ok, prediction} = Replicate.Deployments.create_prediction(deployment, %{prompt: "a 19th century portrait of a wombat gentleman"})
   iex> prediction.status
   "starting"
   ```

--- a/lib/deployments.ex
+++ b/lib/deployments.ex
@@ -3,8 +3,10 @@ defmodule Replicate.Deployments do
   Documentation for `Predictions`.
   """
   @behaviour Replicate.Deployments.Behaviour
-  alias Replicate.Deployments.Deployment
   @replicate_client Application.compile_env(:replicate, :replicate_client, Replicate.Client)
+  alias Replicate.Deployments.Deployment
+  alias Replicate.Models.Version
+  alias Replicate.Predictions.Prediction
 
   @doc """
   Gets a deployment by name, in the format `owner/model-name`.
@@ -23,6 +25,51 @@ defmodule Replicate.Deployments do
   def get(name) do
     [owner, model_name] = String.split(name, "/")
     {:ok, %Deployment{username: owner, name: model_name}}
+  end
+
+  @doc """
+  Create a new prediction with the deployment. The input parameter should be a map of the model inputs.
+
+  ## Examples
+
+  ```
+  iex> {:ok, deployment} = Replicate.Deployments.get("test/model")
+  iex> model = Replicate.Models.get!("stability-ai/stable-diffusion")
+  iex> version = Replicate.Models.get_version!(model, "db21e45d3f7023abc2a46ee38a23973f6dce16bb082a930b0c49861f96d1e5bf")
+  iex> {:ok, prediction} = Replicate.Deployments.create_prediction(deployment, version, %{prompt: "a 19th century portrait of a wombat gentleman"})
+  iex> prediction.status
+  "starting"
+  ```
+  """
+  def create_prediction(
+        %Deployment{username: username, name: name},
+        %Version{id: version_id},
+        input,
+        webhook \\ nil,
+        webhook_completed \\ nil,
+        webhook_event_filter \\ nil,
+        stream \\ nil
+      ) do
+    webhook_parameters =
+      %{
+        "webhook" => webhook,
+        "webhook_completed" => webhook_completed,
+        "webhook_event_filter" => webhook_event_filter,
+        "stream" => stream
+      }
+      |> Enum.filter(fn {_key, value} -> !is_nil(value) end)
+      |> Enum.into(%{})
+
+    body =
+      %{
+        "version" => version_id,
+        "input" => input |> Enum.into(%{})
+      }
+      |> Map.merge(webhook_parameters)
+      |> Jason.encode!()
+
+    @replicate_client.request(:post, "/v1/deployments/#{username}/#{name}/predictions", body)
+    |> parse_response()
   end
 
   defp parse_response({:ok, json_body}) do

--- a/lib/deployments/behaviour.ex
+++ b/lib/deployments/behaviour.ex
@@ -5,6 +5,16 @@ defmodule Replicate.Deployments.Behaviour do
   alias Replicate.Deployments.Deployment
 
   @callback get(String.t(), String.t()) :: {:ok, Deployment.t()} | {:error, String.t()}
-  @callback predictions(Deployment.t()) ::
-              {:ok, [String.t()]} | {:error, String.t()}
+  @callback list_predictions(Deployment.t()) ::
+              {:ok, [Replicate.Predictions.Prediction.t()]} | {:error, String.t()}
+  @callback create_prediction(
+              Deployment.t(),
+              version :: Replicate.Models.Version.t(),
+              input :: %{string: any},
+              webhook :: list(String.t()),
+              webhook_completed :: list(String.t()),
+              webook_event_filter :: list(String.t()),
+              stream :: boolean()
+            ) ::
+              {:ok, Replicate.Predictions.Prediction.t()} | {:error, String.t()}
 end

--- a/lib/deployments/behaviour.ex
+++ b/lib/deployments/behaviour.ex
@@ -1,0 +1,10 @@
+defmodule Replicate.Deployments.Behaviour do
+  @moduledoc """
+  Documentation for the Deployment Behaviour.
+  """
+  alias Replicate.Deployments.Deployment
+
+  @callback get(String.t(), String.t()) :: {:ok, Deployment.t()} | {:error, String.t()}
+  @callback predictions(Deployment.t()) ::
+              {:ok, [String.t()]} | {:error, String.t()}
+end

--- a/lib/deployments/behaviour.ex
+++ b/lib/deployments/behaviour.ex
@@ -4,12 +4,9 @@ defmodule Replicate.Deployments.Behaviour do
   """
   alias Replicate.Deployments.Deployment
 
-  @callback get(String.t(), String.t()) :: {:ok, Deployment.t()} | {:error, String.t()}
-  @callback list_predictions(Deployment.t()) ::
-              {:ok, [Replicate.Predictions.Prediction.t()]} | {:error, String.t()}
+  @callback get(String.t()) :: {:ok, Deployment.t()} | {:error, String.t()}
   @callback create_prediction(
               Deployment.t(),
-              version :: Replicate.Models.Version.t(),
               input :: %{string: any},
               webhook :: list(String.t()),
               webhook_completed :: list(String.t()),

--- a/lib/deployments/deployment.ex
+++ b/lib/deployments/deployment.ex
@@ -1,0 +1,9 @@
+defmodule Replicate.Deployments.Deployment do
+  @moduledoc """
+  `Deployment` struct.
+  """
+  defstruct [
+    :username,
+    :name
+  ]
+end

--- a/lib/mock_client.ex
+++ b/lib/mock_client.ex
@@ -14,7 +14,7 @@ defmodule Replicate.MockClient do
     ],
     urls: %{
       "get" => "https://api.replicate.com/v1/predictions/1234",
-      "cancel" => "https://api.replicate.com/v1/predictions/1234/cancel",
+      "cancel" => "https://api.replicate.com/v1/predictions/1234/cancel"
     }
   }
   @stub_prediction2 %{
@@ -27,7 +27,7 @@ defmodule Replicate.MockClient do
     ],
     urls: %{
       "get" => "https://api.replicate.com/v1/predictions/1235",
-      "cancel" => "https://api.replicate.com/v1/predictions/1235/cancel",
+      "cancel" => "https://api.replicate.com/v1/predictions/1235/cancel"
     }
   }
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Replicate.MixProject do
   def project do
     [
       app: :replicate,
-      version: "1.0.1",
+      version: "1.0.2",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Replicate.MixProject do
   def project do
     [
       app: :replicate,
-      version: "1.0.2",
+      version: "1.0.3",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Replicate.MixProject do
   def project do
     [
       app: :replicate,
-      version: "1.1.0",
+      version: "1.1.1",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/replicate_test.exs
+++ b/test/replicate_test.exs
@@ -3,7 +3,6 @@ defmodule ReplicateTest do
   import Mox
   alias Replicate.Predictions.Prediction
   alias Replicate.Models.Model
-  alias Replicate.Deployments.Deployment
   doctest Replicate
   doctest Replicate.Predictions
   doctest Replicate.Models
@@ -90,6 +89,6 @@ defmodule ReplicateTest do
         prompt: "a 19th century portrait of a wombat gentleman"
       })
 
-    prediction.status == "starting"
+    assert prediction.status == "starting"
   end
 end

--- a/test/replicate_test.exs
+++ b/test/replicate_test.exs
@@ -83,6 +83,21 @@ defmodule ReplicateTest do
   end
 
   test "create a deployment prediction" do
-    deployment = Replicate.Deployments.get("test/model")
+    {:ok, deployment} = Replicate.Deployments.get("test/model")
+
+    model = Replicate.Models.get!("stability-ai/stable-diffusion")
+
+    version =
+      Replicate.Models.get_version!(
+        model,
+        "db21e45d3f7023abc2a46ee38a23973f6dce16bb082a930b0c49861f96d1e5bf"
+      )
+
+    {:ok, prediction} =
+      Replicate.Deployments.create_prediction(deployment, version, %{
+        prompt: "a 19th century portrait of a wombat gentleman"
+      })
+
+    prediction.status == "starting"
   end
 end

--- a/test/replicate_test.exs
+++ b/test/replicate_test.exs
@@ -86,7 +86,7 @@ defmodule ReplicateTest do
     {:ok, deployment} = Replicate.Deployments.get("test/model")
 
     {:ok, prediction} =
-      Replicate.Deployments.create_prediction(deployment, version, %{
+      Replicate.Deployments.create_prediction(deployment, %{
         prompt: "a 19th century portrait of a wombat gentleman"
       })
 

--- a/test/replicate_test.exs
+++ b/test/replicate_test.exs
@@ -85,14 +85,6 @@ defmodule ReplicateTest do
   test "create a deployment prediction" do
     {:ok, deployment} = Replicate.Deployments.get("test/model")
 
-    model = Replicate.Models.get!("stability-ai/stable-diffusion")
-
-    version =
-      Replicate.Models.get_version!(
-        model,
-        "db21e45d3f7023abc2a46ee38a23973f6dce16bb082a930b0c49861f96d1e5bf"
-      )
-
     {:ok, prediction} =
       Replicate.Deployments.create_prediction(deployment, version, %{
         prompt: "a 19th century portrait of a wombat gentleman"

--- a/test/replicate_test.exs
+++ b/test/replicate_test.exs
@@ -3,9 +3,11 @@ defmodule ReplicateTest do
   import Mox
   alias Replicate.Predictions.Prediction
   alias Replicate.Models.Model
+  alias Replicate.Deployments.Deployment
   doctest Replicate
   doctest Replicate.Predictions
   doctest Replicate.Models
+  doctest Replicate.Deployments
 
   # Make sure mocks are verified when the test exits
   setup :verify_on_exit!
@@ -78,5 +80,9 @@ defmodule ReplicateTest do
     first_version = Enum.at(versions, 0)
     assert first_version.id == "v1"
     assert first_version.cog_version == "0.3.0"
+  end
+
+  test "create a deployment prediction" do
+    deployment = Replicate.Deployments.get("test/model")
   end
 end


### PR DESCRIPTION
Add deployments to the Elixir client. Here's it in action. Tested with `mix test` and by running it locally.

```elixir
iex> {:ok, deployment} = Replicate.Deployments.get("test/model")
iex> {:ok, prediction} = Replicate.Deployments.create_prediction(deployment, %{prompt: "a 19th century portrait of a wombat gentleman"})
```