### PR TITLE
Add created_at field to model struct and test

### DIFF
--- a/lib/mock_client.ex
+++ b/lib/mock_client.ex
@@ -56,7 +56,8 @@ defmodule Replicate.MockClient do
     "license_url" => nil,
     "run_count" => 12345,
     "cover_image_url" => nil,
-    "latest_version" => @stub_version2
+    "latest_version" => @stub_version2,
+    "created_at" => "2022-04-26T19:29:04.418669Z"
   }
 
   @stub_hardware [

--- a/lib/models.ex
+++ b/lib/models.ex
@@ -145,6 +145,7 @@ defmodule Replicate.Models do
       run_count: 12345,
       cover_image_url: nil,
       default_example: nil,
+      created_at: "2022-04-26T19:29:04.418669Z",
       latest_version: %{
         "cog_version" => "0.3.0",
         "created_at" => "2022-03-21T13:01:04.418669Z",

--- a/lib/models/behaviour.ex
+++ b/lib/models/behaviour.ex
@@ -2,6 +2,19 @@ defmodule Replicate.Models.Behaviour do
   @moduledoc """
   Documentation for the Model Behaviour
   """
+
+  @type create_opts :: [
+          owner: String.t(),
+          name: String.t(),
+          visibility: String.t(),
+          hardware: String.t(),
+          description: String.t(),
+          github_url: String.t(),
+          paper_url: String.t(),
+          license_url: String.t(),
+          cover_image_url: String.t()
+        ]
+
   @callback get!(name :: String.t()) :: Replicate.Models.Model.t()
   @callback get(name :: String.t()) :: {:ok, Replicate.Models.Model.t()} | {:error, String.t()}
   @callback get_version!(Replicate.Models.Model.t(), version :: String.t()) ::
@@ -13,13 +26,5 @@ defmodule Replicate.Models.Behaviour do
               next: String.t(),
               previous: String.t()
             }
-  @callback create(
-              owner :: String.t(),
-              name :: String.t(),
-              description :: String.t(),
-              github_url :: String.t(),
-              paper_url :: String.t(),
-              license_url :: String.t(),
-              cover_image_url :: String.t()
-            ) :: {:ok, Replicate.Models.Model.t()} | {:error, String.t()}
+  @callback create(create_opts) :: {:ok, Replicate.Models.Model.t()} | {:error, String.t()}
 end

--- a/lib/models/model.ex
+++ b/lib/models/model.ex
@@ -1,4 +1,20 @@
 defmodule Replicate.Models.Model do
+  @type t :: %__MODULE__{
+          url: String.t(),
+          owner: String.t(),
+          name: String.t(),
+          description: String.t(),
+          visibility: String.t(),
+          github_url: String.t(),
+          paper_url: String.t(),
+          license_url: String.t(),
+          run_count: integer(),
+          cover_image_url: String.t(),
+          default_example: String.t(),
+          latest_version: Replicate.Models.Version.t(),
+          created_at: String.t()
+        }
+
   @moduledoc """
   `Model` struct.
   """
@@ -14,6 +30,7 @@ defmodule Replicate.Models.Model do
     :run_count,
     :cover_image_url,
     :default_example,
-    :latest_version
+    :latest_version,
+    :created_at
   ]
 end

--- a/lib/models/version.ex
+++ b/lib/models/version.ex
@@ -2,5 +2,12 @@ defmodule Replicate.Models.Version do
   @moduledoc """
   `Version` struct.
   """
+  @type t :: %__MODULE__{
+          id: String.t(),
+          created_at: String.t(),
+          cog_version: String.t(),
+          openapi_schema: map()
+        }
+
   defstruct [:id, :created_at, :cog_version, :openapi_schema]
 end

--- a/test/replicate_test.exs
+++ b/test/replicate_test.exs
@@ -116,6 +116,7 @@ defmodule ReplicateTest do
                run_count: 12345,
                cover_image_url: nil,
                default_example: nil,
+               created_at: "2022-04-26T19:29:04.418669Z",
                latest_version: %{
                  "cog_version" => "0.3.0",
                  "created_at" => "2022-03-21T13:01:04.418669Z",


### PR DESCRIPTION
The `Replicate.Models.list/0` function currently breaks due to the API returning `created_at` as a field in the `model` response. 

```
** (KeyError) key :created_at not found
    (replicate 1.2.0) anonymous fn/2 in Replicate.Models.Model.__struct__/1
    (stdlib 5.2.3) maps.erl:416: :maps.fold_1/4
    (elixir 1.16.3) lib/kernel.ex:2434: Kernel.struct!/2
    (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
    (replicate 1.2.0) lib/models.ex:163: Replicate.Models.list/0
    iex:1: (file)
```

This adds the field to the model struct as well as to the mock client's model response structure.
It also updates the `Replicate.Models.Behaviour` to require the `opts` keyword instead of the 7 arguments. 