### PR TITLE
pluralize webhook_events_key

### DIFF
--- a/lib/deployments.ex
+++ b/lib/deployments.ex
@@ -44,14 +44,14 @@ defmodule Replicate.Deployments do
         input,
         webhook \\ nil,
         webhook_completed \\ nil,
-        webhook_event_filter \\ nil,
+        webhook_events_filter \\ nil,
         stream \\ nil
       ) do
     webhook_parameters =
       %{
         "webhook" => webhook,
         "webhook_completed" => webhook_completed,
-        "webhook_event_filter" => webhook_event_filter,
+        "webhook_events_filter" => webhook_events_filter,
         "stream" => stream
       }
       |> Enum.filter(fn {_key, value} -> !is_nil(value) end)

--- a/lib/predictions.ex
+++ b/lib/predictions.ex
@@ -119,14 +119,14 @@ defmodule Replicate.Predictions do
         input,
         webhook \\ nil,
         webhook_completed \\ nil,
-        webhook_event_filter \\ nil,
+        webhook_events_filter \\ nil,
         stream \\ nil
       ) do
     webhook_parameters =
       %{
         "webhook" => webhook,
         "webhook_completed" => webhook_completed,
-        "webhook_event_filter" => webhook_event_filter,
+        "webhook_events_filter" => webhook_events_filter,
         "stream" => stream
       }
       |> Enum.filter(fn {_key, value} -> !is_nil(value) end)

--- a/lib/predictions/behaviour.ex
+++ b/lib/predictions/behaviour.ex
@@ -15,13 +15,13 @@ defmodule Replicate.Predictions.Behaviour do
               input :: %{String.t() => any()},
               webhook :: list(String.t()),
               webhook_completed :: list(String.t()),
-              webook_event_filter :: list(String.t())
+              webook_evenst_filter :: list(String.t())
             ) :: {:ok, Prediction.t()} | {:error, String.t()}
   @callback create(
               model :: String.t(),
               input :: %{String.t() => any()},
               webhook :: list(String.t()),
               webhook_completed :: list(String.t()),
-              webook_event_filter :: list(String.t())
+              webook_events_filter :: list(String.t())
             ) :: {:ok, Prediction.t()} | {:error, String.t()}
 end


### PR DESCRIPTION
The Replicate API key allows you to create predictions in deployments and individual predictions, declaring an array of statuses for which you want Replicate to send updates to the webhook.

This PR fixes a typo. The key is `webhook_events_filter`, not `webhook_event_filter`.

https://replicate.com/docs/reference/http#predictions.create-request-body-webhook-events-filter
https://replicate.com/docs/reference/http#deployments.predictions.create-request-body-webhook-events-filter